### PR TITLE
Reverting change to 7.16.0 (back to 7.11.0)

### DIFF
--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -13,7 +13,7 @@ private object AppDependencies {
 
   private val playHealthVersion = "2.1.0"
   private val logbackJsonLoggerVersion = "3.1.0"
-  private val frontendBootstrapVersion = "7.16.0"
+  private val frontendBootstrapVersion = "7.11.0"
   private val govukTemplateVersion = "5.2.0"
   private val playUiVersion = "7.0.1"
   private val playPartialsVersion = "5.3.0"


### PR DESCRIPTION
There have been some significant changes to the latest play-filters
(incl. as a transitive dependency) that change the behaviour of how
session timeout is handled: various session attributes are wiped if
the last requested timestamp is not found.