### PR TITLE
APIS-2260 Fix integration test

### DIFF
--- a/test/it/uk/gov/hmrc/api/testlogin/LoginSpec.scala
+++ b/test/it/uk/gov/hmrc/api/testlogin/LoginSpec.scala
@@ -49,9 +49,8 @@ class LoginSpec extends BaseSpec {
       on(ContinuePage)
 
       And("The cookie is set in the session")
-      val encryptedMdtpCookie = webDriver.manage().getCookies.toSet.find(_.getName == "mdtp").get
-      val mdtpCookieValue = SessionCookieCrypto.decrypt(Crypted(encryptedMdtpCookie.getValue)).value
-      mdtpCookieValue should include ("authToken=Bearer+1234")
+      val encryptedMdtpCookie = webDriver.manage().getCookies.toSet.find(_.getName == "mdtp")
+      encryptedMdtpCookie should be ('defined)
     }
 
     scenario("Failed login") {


### PR DESCRIPTION
Remove test that checks indirect mocked result.  The authToken is set by a call made from test user api  (which we mock out but don't mock the cookie) to auth login api.  This test belongs in test user api not here.